### PR TITLE
fix: Do not always pop threads

### DIFF
--- a/upload_events.py
+++ b/upload_events.py
@@ -83,7 +83,8 @@ def upload_events(file_name: Path, dsn: str, project_id: int, project_slug: str,
 
             for event in events2:
                 event.pop('project', None)
-                event.pop('threads', None)
+                if 'exception' in event:
+                    event.pop('threads', None)
                 event.pop('debug_meta', None)
 
                 for stacktrace_info in find_stacktraces_in_data(event):


### PR DESCRIPTION
We're trying very hard to dive under the size limits, but in some cases threads is what is being grouped by. Let's not pop threads if there is no exception interface